### PR TITLE
Fixes `TypeError` on non-string values in args

### DIFF
--- a/lib/value-arg.js
+++ b/lib/value-arg.js
@@ -7,7 +7,7 @@ class ValueArg {
   constructor (value) {
     this.isOptionValueNotationValue = reBeginsWithValueMarker.test(value)
     /* if the value marker is present at the value beginning, strip it */
-    this.value = value ? value.replace(reBeginsWithValueMarker, '') : value
+    this.value = typeof value === 'string' ? value.replace(reBeginsWithValueMarker, '') : value
   }
 
   isDefined () {


### PR DESCRIPTION
If an argument list has a non string object in it, like in the `argv` variable :
```js
const cmdArgs = require('command-line-args');
const optionDefinitions = [
  { name: 'verbose', alias: 'v', type: Boolean },
  { name: 'src', type: String, multiple: true, defaultOption: true },
  { name: 'timeout', alias: 't', type: Number }
];

let args = [  '-t', 120, '--src', 'Delta', 'Force', '--verbose' ];

const options = cmdArgs(optionDefinitions, {argv: args});
```
it gives a `TypeError`.

This commit fixes this issue.