### PR TITLE
Add the stopParsingAtFirstUnknown parsing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ $ npm install command-line-args --save
 ### commandLineArgs(optionDefinitions, [options]) ⇒ <code>object</code> ⏏
 Returns an object containing all options set on the command line. By default it parses the global  [`process.argv`](https://nodejs.org/api/process.html#process_process_argv) array.
 
-By default, an exception is thrown if the user sets an unknown option (one without a valid [definition](#exp_module_definition--OptionDefinition)). To enable __partial parsing__, invoke `commandLineArgs` with the `partial` option - all unknown arguments will be returned in the `_unknown` property.
+By default, an exception is thrown if the user sets an unknown option (one without a valid [definition](#exp_module_definition--OptionDefinition)). To enable __partial parsing__, invoke `commandLineArgs` with the `partial` option - all unknown arguments will be returned in the `_unknown` property. If `stopParsingAtFirstUnknown` option is also set all arguments after the first unknown argument will also be skipped and added to the `_unknown` property.
 
 **Kind**: Exported function  
 **Throws**:

--- a/lib/command-line-args.js
+++ b/lib/command-line-args.js
@@ -15,6 +15,7 @@ module.exports = commandLineArgs
  * @param [options] {object} - Options.
  * @param [options.argv] {string[]} - An array of strings, which if passed will be parsed instead  of `process.argv`.
  * @param [options.partial] {boolean} - If `true`, an array of unknown arguments is returned in the `_unknown` property of the output.
+ * @param [options.stopParsingAtFirstUnknown] {boolean} - If `true`, the parsing will stop at the first unknown argument and the remaining arguments will be put in `_unknown`.
  * @returns {object}
  * @throws `UNKNOWN_OPTION` if `options.partial` is false and the user set an undefined option
  * @throws `NAME_MISSING` if an option definition is missing the required `name` property
@@ -39,10 +40,15 @@ function commandLineArgs (optionDefinitions, options) {
 
   const OutputClass = definitions.isGrouped() ? require('./grouped-output') : require('./output')
   const output = new OutputClass(definitions, options)
+  const stopParsingAtFirstUnknown = 'stopParsingAtFirstUnknown' in options ? options.stopParsingAtFirstUnknown : false
   let optionName
 
   const option = require('./option')
   for (const arg of argv) {
+    if (stopParsingAtFirstUnknown && output.unknown.length > 0) {
+      output.unknown.push(arg)
+      continue
+    }
     if (option.isOption(arg)) {
       optionName = output.setFlag(arg) ? undefined : arg
     } else {

--- a/test/partial.js
+++ b/test/partial.js
@@ -198,3 +198,16 @@ runner.test('partial: mulitple unknowns with same name', function () {
     _unknown: [ '--unknown', '--unknown=something', '--unknown' ]
   })
 })
+
+runner.test('partial: stopParsingAtFirstUnknown', function () {
+  const definitions = [
+    { name: 'one', type: Boolean },
+    { name: 'two', type: Boolean }
+  ]
+  const argv = [ '--one', 'a', '--two' ]
+  const options = commandLineArgs(definitions, { argv, partial: true, stopParsingAtFirstUnknown: true })
+  a.deepStrictEqual(options, {
+    one: true,
+    _unknown: [ 'a', '--two' ]
+  })
+})


### PR DESCRIPTION
With this options, parsing arguments similar to docker is possible. For example `docker run -i -t centos ls -l -a`, where the first parser will parse out the command, `run` in this case, the second parser will parse `-i` and `-t` and then pass the remaining arguments to another parser. Before this change if the second parser had a `-l` or `-a` option they would be parsed and not passed on.