### PR TITLE
Add disableGreedyMultiple parse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Set this flag if the option takes a list of values. You will receive an array of
 **Kind**: instance property of <code>[OptionDefinition](#exp_module_definition--OptionDefinition)</code>  
 <a name="module_definition--OptionDefinition.OptionDefinition+defaultOption"></a>
 
+If the `disableGreedyMultiple` parsing option is set example 1 above will not be supported and `two.js` will be added to the `_unknown` property in the results.
+
 ### option.defaultOption : <code>boolean</code>
 Any unclaimed command-line args will be set on this option. This flag is typically set on the most commonly-used option to make for more concise usage (i.e. `$ myapp *.js` instead of `$ myapp --files *.js`).
 

--- a/lib/command-line-args.js
+++ b/lib/command-line-args.js
@@ -15,6 +15,7 @@ module.exports = commandLineArgs
  * @param [options] {object} - Options.
  * @param [options.argv] {string[]} - An array of strings, which if passed will be parsed instead  of `process.argv`.
  * @param [options.partial] {boolean} - If `true`, an array of unknown arguments is returned in the `_unknown` property of the output.
+ * @param [options.disableGreedyMultiple] {boolean} - If `true`, multiple arguments with the format `-m a b` will not be accepted.
  * @returns {object}
  * @throws `UNKNOWN_OPTION` if `options.partial` is false and the user set an undefined option
  * @throws `NAME_MISSING` if an option definition is missing the required `name` property

--- a/lib/output.js
+++ b/lib/output.js
@@ -20,6 +20,7 @@ class Output {
     this.output = {}
     this.unknown = []
     this.definitions = definitions
+    this.disableGreedyMultiple = 'disableGreedyMultiple' in this.options ? this.options.disableGreedyMultiple : false
     this._assignDefaultValues()
   }
 
@@ -64,6 +65,9 @@ class Output {
     }
   }
 
+  /**
+   * Return `true` when an option value was set or greedy multiple is disabled. Return `false` if multiple options should continue to be added.
+   */
   setOptionValue (optionArg, value) {
     const ValueArg = require('./value-arg')
     const valueArg = new ValueArg(value)
@@ -85,7 +89,7 @@ class Output {
       } else {
         outputValue.value.push(valueArg.value)
       }
-      return false
+      return this.disableGreedyMultiple
     } else {
       outputValue.value = valueArg.value
       return true

--- a/test/multiple.js
+++ b/test/multiple.js
@@ -31,3 +31,12 @@ runner.test('multiple: boolean unset', function () {
   const result = commandLineArgs(optionDefinitions, { argv })
   a.deepStrictEqual(result, { })
 })
+
+runner.test('multiple: disableGreedyMultiple', function () {
+  const argv = ['--one', 'a', '--one', 'b', 'c', '--one', 'd']
+  const optionDefinitions = [
+      { name: 'one', multiple: true }
+  ]
+  const result = commandLineArgs(optionDefinitions, { argv, disableGreedyMultiple: true, partial: true })
+  a.deepStrictEqual(result, { one: ['a', 'b', 'd'], _unknown: ['c'] })
+})


### PR DESCRIPTION
When using multiple in combination with partial the greediness of multiple prevents unknown arguments following multiple arguments. This option disables the `-m a b` form and with treat `b` as an unknown argument.

See https://github.com/75lb/command-line-args/issues/52