### PR TITLE
Attach invalidOption to `UNKNOWN_OPTION` errors

### DIFF
--- a/lib/argv.js
+++ b/lib/argv.js
@@ -63,6 +63,7 @@ class Argv extends Array {
   /**
    * Inspect the user-supplied options for validation issues.
    * @throws `UNKNOWN_OPTION`
+   * @property {string} invalidOption - The first invalid option found by the parser.
    */
   validate (definitions, options) {
     options = options || {}
@@ -80,16 +81,18 @@ class Argv extends Array {
       if (optionWithoutDefinition) {
         halt(
           'UNKNOWN_OPTION',
-          'Unknown option: ' + invalidOption
+          'Unknown option: ' + invalidOption,
+          { invalidOption: invalidOption }
         )
       }
     }
   }
 }
 
-function halt (name, message) {
+function halt (name, message, additionalProps) {
   const err = new Error(message)
   err.name = name
+  Object.assign(err, additionalProps)
   throw err
 }
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   ],
   "author": "Lloyd Brookes <75pound@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "devDependencies": {
     "coveralls": "^2.13.1",
     "jsdoc-to-markdown": "^3.0.0",

--- a/test/exceptions.js
+++ b/test/exceptions.js
@@ -104,6 +104,7 @@ runner.test('err-invalid-definition: value without option definition', function 
     a.fail()
   } catch (err) {
     a.strictEqual(err.name, 'UNKNOWN_OPTION')
+    a.strictEqual(err.invalidOption, '--two')
   }
 
   try {
@@ -111,6 +112,7 @@ runner.test('err-invalid-definition: value without option definition', function 
     a.fail()
   } catch (err) {
     a.strictEqual(err.name, 'UNKNOWN_OPTION')
+    a.strictEqual(err.invalidOption, '--two')
   }
 
   try {
@@ -118,6 +120,7 @@ runner.test('err-invalid-definition: value without option definition', function 
     a.fail()
   } catch (err) {
     a.strictEqual(err.name, 'UNKNOWN_OPTION')
+    a.strictEqual(err.invalidOption, '-a')
   }
 
   try {
@@ -125,6 +128,7 @@ runner.test('err-invalid-definition: value without option definition', function 
     a.fail()
   } catch (err) {
     a.strictEqual(err.name, 'UNKNOWN_OPTION', 'getOpts')
+    a.strictEqual(err.invalidOption, '-s')
   }
 })
 


### PR DESCRIPTION
I'm using command-line-args to parse in a cli in which I'm formatting / printing my own errors. Right now, I catch the `UNKNOWN_OPTION` error when it fires and prints your message straight to the user (i.e. `"Unknown option: optionname"`) . I'd love to have the ability to format the error / give my own details, though, and was hoping to find the options outside of the message string on the error object so that I could format my message e.g. 
```
catch(e) {
  if (e.name === 'UNKNOWN_OPTION') {
      console.error(`You provided an unknown option ${e.invalidOption}. Please check your spelling and try again.`);
  }
}
```
