### PR TITLE
Specify engine node>4.0.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   ],
   "author": "Lloyd Brookes <75pound@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "devDependencies": {
     "coveralls": "^2.13.1",
     "jsdoc-to-markdown": "^3.0.0",


### PR DESCRIPTION
Closes #69 

(which I'm realizing was probably superfluous to open...) 👍