### PR TITLE
Problem with crossed options

### DIFF
--- a/test/ambiguous-input.js
+++ b/test/ambiguous-input.js
@@ -42,3 +42,13 @@ runner.test('ambiguous input: value looks like an option 4', function () {
     colour: '--red'
   })
 })
+
+runner.test('ambiguous input: value looks like another option', function () {
+  const optionDefinitions = [
+    { name: 'colour', type: String, alias: 'c' },
+    { name: 'heat', type: String, alias: 'h' }
+  ]
+  a.deepStrictEqual(commandLineArgs(optionDefinitions, { argv: [ '--colour', '--heat warm' ] }), {
+    colour: '--heat warm'
+  })
+})


### PR DESCRIPTION
Found a parsing thing that doesn't work - it seems to get confused about having a space *within* a particular argv and mis-matches value?

I was trying to do somethin glike

/thing/like/a/shell -c "--instance dog"

And encountered this result.  

Probably some small oversight...
