### PR TITLE
Parse correctly when Node runs with --eval or -e

### DIFF
--- a/lib/argv-tools.mjs
+++ b/lib/argv-tools.mjs
@@ -37,7 +37,10 @@ class ArgvArray extends Array {
     } else {
       /* if no argv supplied, assume we are parsing process.argv */
       argv = process.argv.slice(0)
-      argv.splice(0, 2)
+
+      const deleteCount =
+        process.execArgv.some(val => ['--eval', '-e'].includes(val)) ? 1 : 2
+      argv.splice(0, deleteCount)
     }
     argv.forEach(arg => this.push(String(arg)))
   }


### PR DESCRIPTION
Parse correctly when Node.js runs with `--eval` or `-e` option