### PR TITLE
Allow for defaultOption to be set to false

### DIFF
--- a/lib/option-definitions.mjs
+++ b/lib/option-definitions.mjs
@@ -84,7 +84,7 @@ class Definitions extends Array {
       )
     }
 
-    const duplicateDefaultOption = hasDuplicates(this.map(def => def.defaultOption))
+    const duplicateDefaultOption = this.filter(def => def.defaultOption === true).length > 1;
     if (duplicateDefaultOption) {
       halt(
         'INVALID_DEFINITIONS',

--- a/test/default-option.mjs
+++ b/test/default-option.mjs
@@ -39,6 +39,20 @@ runner.test('defaultOption: multiple-defaultOption values spread out', function 
   })
 })
 
+runner.test('defaultOption: can be false', function () {
+  const optionDefinitions = [
+    { name: 'one', defaultOption: false },
+    { name: 'two', defaultOption: false },
+    { name: 'files', defaultOption: true, multiple: true }
+  ]
+  const argv = ['--one', '1', 'file1', 'file2', '--two', '2']
+  a.deepStrictEqual(commandLineArgs(optionDefinitions, { argv }), {
+    one: '1',
+    two: '2',
+    files: ['file1', 'file2']
+  })
+})
+
 runner.test('defaultOption: multiple-defaultOption values spread out 2', function () {
   const optionDefinitions = [
     { name: 'one', type: Boolean },


### PR DESCRIPTION
In the existing test, it will spit out an error:

```
Only one option definition can be the defaultOption
```

This is confusing if you've explictly set it to false and have no default options or one default option set to true.