### PR TITLE
Update dependencies to latest CJS / Node v8 compatible

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -62,7 +62,7 @@ function arrayify (input) {
     return Array.from(input)
   }
 
-  return [ input ]
+  return [input]
 }
 
 /**
@@ -341,15 +341,17 @@ function isExecArg (arg) {
 }
 
 /**
- * For type-checking Javascript values.
+ * Isomorphic, functional type-checking for Javascript.
  * @module typical
  * @typicalname t
  * @example
  * const t = require('typical')
+ * const allDefined = array.every(t.isDefined)
  */
 
 /**
- * Returns true if input is a number
+ * Returns true if input is a number. It is a more reasonable alternative to `typeof n` which returns `number` for `NaN` and `Infinity`.
+ *
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -406,15 +408,15 @@ function isPlainObject (input) {
 }
 
 /**
- * An array-like value has all the properties of an array, but is not an array instance. Examples in the `arguments` object. Returns true if the input value is an object, not null and has a `length` property with a numeric value.
+ * An array-like value has all the properties of an array yet is not an array instance. An example is the `arguments` object. Returns `true`` if the input value is an object, not `null`` and has a `length` property set with a numeric value.
  *
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  * @example
  * function sum(x, y){
- *     console.log(t.isArrayLike(arguments))
- *     // prints `true`
+ *   console.log(t.isArrayLike(arguments))
+ *   // prints `true`
  * }
  */
 function isArrayLike$2 (input) {
@@ -422,7 +424,7 @@ function isArrayLike$2 (input) {
 }
 
 /**
- * returns true if the typeof input is `'object'`, but not null!
+ * Returns true if the typeof input is `'object'` but not null.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -432,7 +434,7 @@ function isObject$2 (input) {
 }
 
 /**
- * Returns true if the input value is defined
+ * Returns true if the input value is defined.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -442,43 +444,43 @@ function isDefined (input) {
 }
 
 /**
- * Returns true if the input value is a string
+ * Returns true if the input value is undefined.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isString (input) {
-  return typeof input === 'string'
+function isUndefined (input) {
+  return !isDefined(input)
 }
 
 /**
- * Returns true if the input value is a boolean
+ * Returns true if the input value is null.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isBoolean (input) {
-  return typeof input === 'boolean'
+function isNull (input) {
+ return input === null
 }
 
 /**
- * Returns true if the input value is a function
+ * Returns true if the input value is not one of `undefined`, `null`, or `NaN`.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isFunction (input) {
-  return typeof input === 'function'
+function isDefinedValue (input) {
+ return isDefined(input) && !isNull(input) && !Number.isNaN(input)
 }
 
 /**
- * Returns true if the input value is an es2015 `class`.
+ * Returns true if the input value is an ES2015 `class`.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
 function isClass (input) {
-  if (isFunction(input)) {
+  if (typeof input === 'function') {
     return /^class /.test(Function.prototype.toString.call(input))
   } else {
     return false
@@ -571,19 +573,41 @@ function isIterable (input) {
   }
 }
 
+/**
+ * Returns true if the input value is a string. The equivalent of `typeof input === 'string'` for use in funcitonal contexts.
+ * @param {*} - the input to test
+ * @returns {boolean}
+ * @static
+ */
+function isString (input) {
+  return typeof input === 'string'
+}
+
+/**
+ * Returns true if the input value is a function. The equivalent of `typeof input === 'function'` for use in funcitonal contexts.
+ * @param {*} - the input to test
+ * @returns {boolean}
+ * @static
+ */
+function isFunction (input) {
+  return typeof input === 'function'
+}
+
 var t = {
   isNumber,
-  isString,
-  isBoolean,
   isPlainObject,
   isArrayLike: isArrayLike$2,
   isObject: isObject$2,
   isDefined,
-  isFunction,
+  isUndefined,
+  isNull,
+  isDefinedValue,
   isClass,
   isPrimitive,
   isPromise,
-  isIterable
+  isIterable,
+  isString,
+  isFunction
 };
 
 /**

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -58,7 +58,7 @@ function arrayify (input) {
     return Array.from(input)
   }
 
-  return [ input ]
+  return [input]
 }
 
 /**
@@ -337,15 +337,17 @@ function isExecArg (arg) {
 }
 
 /**
- * For type-checking Javascript values.
+ * Isomorphic, functional type-checking for Javascript.
  * @module typical
  * @typicalname t
  * @example
  * const t = require('typical')
+ * const allDefined = array.every(t.isDefined)
  */
 
 /**
- * Returns true if input is a number
+ * Returns true if input is a number. It is a more reasonable alternative to `typeof n` which returns `number` for `NaN` and `Infinity`.
+ *
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -402,15 +404,15 @@ function isPlainObject (input) {
 }
 
 /**
- * An array-like value has all the properties of an array, but is not an array instance. Examples in the `arguments` object. Returns true if the input value is an object, not null and has a `length` property with a numeric value.
+ * An array-like value has all the properties of an array yet is not an array instance. An example is the `arguments` object. Returns `true`` if the input value is an object, not `null`` and has a `length` property set with a numeric value.
  *
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  * @example
  * function sum(x, y){
- *     console.log(t.isArrayLike(arguments))
- *     // prints `true`
+ *   console.log(t.isArrayLike(arguments))
+ *   // prints `true`
  * }
  */
 function isArrayLike$2 (input) {
@@ -418,7 +420,7 @@ function isArrayLike$2 (input) {
 }
 
 /**
- * returns true if the typeof input is `'object'`, but not null!
+ * Returns true if the typeof input is `'object'` but not null.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -428,7 +430,7 @@ function isObject$2 (input) {
 }
 
 /**
- * Returns true if the input value is defined
+ * Returns true if the input value is defined.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -438,43 +440,43 @@ function isDefined (input) {
 }
 
 /**
- * Returns true if the input value is a string
+ * Returns true if the input value is undefined.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isString (input) {
-  return typeof input === 'string'
+function isUndefined (input) {
+  return !isDefined(input)
 }
 
 /**
- * Returns true if the input value is a boolean
+ * Returns true if the input value is null.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isBoolean (input) {
-  return typeof input === 'boolean'
+function isNull (input) {
+ return input === null
 }
 
 /**
- * Returns true if the input value is a function
+ * Returns true if the input value is not one of `undefined`, `null`, or `NaN`.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isFunction (input) {
-  return typeof input === 'function'
+function isDefinedValue (input) {
+ return isDefined(input) && !isNull(input) && !Number.isNaN(input)
 }
 
 /**
- * Returns true if the input value is an es2015 `class`.
+ * Returns true if the input value is an ES2015 `class`.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
 function isClass (input) {
-  if (isFunction(input)) {
+  if (typeof input === 'function') {
     return /^class /.test(Function.prototype.toString.call(input))
   } else {
     return false
@@ -567,19 +569,41 @@ function isIterable (input) {
   }
 }
 
+/**
+ * Returns true if the input value is a string. The equivalent of `typeof input === 'string'` for use in funcitonal contexts.
+ * @param {*} - the input to test
+ * @returns {boolean}
+ * @static
+ */
+function isString (input) {
+  return typeof input === 'string'
+}
+
+/**
+ * Returns true if the input value is a function. The equivalent of `typeof input === 'function'` for use in funcitonal contexts.
+ * @param {*} - the input to test
+ * @returns {boolean}
+ * @static
+ */
+function isFunction (input) {
+  return typeof input === 'function'
+}
+
 var t = {
   isNumber,
-  isString,
-  isBoolean,
   isPlainObject,
   isArrayLike: isArrayLike$2,
   isObject: isObject$2,
   isDefined,
-  isFunction,
+  isUndefined,
+  isNull,
+  isDefinedValue,
   isClass,
   isPrimitive,
   isPromise,
-  isIterable
+  isIterable,
+  isString,
+  isFunction
 };
 
 /**

--- a/dist/tests.js
+++ b/dist/tests.js
@@ -64,7 +64,7 @@ function arrayify (input) {
     return Array.from(input)
   }
 
-  return [ input ]
+  return [input]
 }
 
 /**
@@ -343,15 +343,17 @@ function isExecArg (arg) {
 }
 
 /**
- * For type-checking Javascript values.
+ * Isomorphic, functional type-checking for Javascript.
  * @module typical
  * @typicalname t
  * @example
  * const t = require('typical')
+ * const allDefined = array.every(t.isDefined)
  */
 
 /**
- * Returns true if input is a number
+ * Returns true if input is a number. It is a more reasonable alternative to `typeof n` which returns `number` for `NaN` and `Infinity`.
+ *
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -408,15 +410,15 @@ function isPlainObject (input) {
 }
 
 /**
- * An array-like value has all the properties of an array, but is not an array instance. Examples in the `arguments` object. Returns true if the input value is an object, not null and has a `length` property with a numeric value.
+ * An array-like value has all the properties of an array yet is not an array instance. An example is the `arguments` object. Returns `true`` if the input value is an object, not `null`` and has a `length` property set with a numeric value.
  *
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  * @example
  * function sum(x, y){
- *     console.log(t.isArrayLike(arguments))
- *     // prints `true`
+ *   console.log(t.isArrayLike(arguments))
+ *   // prints `true`
  * }
  */
 function isArrayLike$2 (input) {
@@ -424,7 +426,7 @@ function isArrayLike$2 (input) {
 }
 
 /**
- * returns true if the typeof input is `'object'`, but not null!
+ * Returns true if the typeof input is `'object'` but not null.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -434,7 +436,7 @@ function isObject$2 (input) {
 }
 
 /**
- * Returns true if the input value is defined
+ * Returns true if the input value is defined.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
@@ -444,43 +446,43 @@ function isDefined (input) {
 }
 
 /**
- * Returns true if the input value is a string
+ * Returns true if the input value is undefined.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isString (input) {
-  return typeof input === 'string'
+function isUndefined (input) {
+  return !isDefined(input)
 }
 
 /**
- * Returns true if the input value is a boolean
+ * Returns true if the input value is null.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isBoolean (input) {
-  return typeof input === 'boolean'
+function isNull (input) {
+ return input === null
 }
 
 /**
- * Returns true if the input value is a function
+ * Returns true if the input value is not one of `undefined`, `null`, or `NaN`.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
-function isFunction (input) {
-  return typeof input === 'function'
+function isDefinedValue (input) {
+ return isDefined(input) && !isNull(input) && !Number.isNaN(input)
 }
 
 /**
- * Returns true if the input value is an es2015 `class`.
+ * Returns true if the input value is an ES2015 `class`.
  * @param {*} - the input to test
  * @returns {boolean}
  * @static
  */
 function isClass (input) {
-  if (isFunction(input)) {
+  if (typeof input === 'function') {
     return /^class /.test(Function.prototype.toString.call(input))
   } else {
     return false
@@ -573,19 +575,41 @@ function isIterable (input) {
   }
 }
 
+/**
+ * Returns true if the input value is a string. The equivalent of `typeof input === 'string'` for use in funcitonal contexts.
+ * @param {*} - the input to test
+ * @returns {boolean}
+ * @static
+ */
+function isString (input) {
+  return typeof input === 'string'
+}
+
+/**
+ * Returns true if the input value is a function. The equivalent of `typeof input === 'function'` for use in funcitonal contexts.
+ * @param {*} - the input to test
+ * @returns {boolean}
+ * @static
+ */
+function isFunction (input) {
+  return typeof input === 'function'
+}
+
 var t = {
   isNumber,
-  isString,
-  isBoolean,
   isPlainObject,
   isArrayLike: isArrayLike$2,
   isObject: isObject$2,
   isDefined,
-  isFunction,
+  isUndefined,
+  isNull,
+  isDefinedValue,
   isClass,
   isPrimitive,
   isPromise,
-  isIterable
+  isIterable,
+  isString,
+  isFunction
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "5.2.1",
       "license": "MIT",
       "dependencies": {
-        "array-back": "^3.1.0",
+        "array-back": "^4.0.2",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
+        "typical": "^5.2.0"
       },
       "devDependencies": {
         "coveralls": "^3.1.1",
-        "jsdoc-to-markdown": "^7.1.1",
+        "jsdoc-to-markdown": "^8.0.0",
         "rollup": "~1.7.4",
         "test-runner": "^0.5.1"
       },
@@ -25,15 +25,27 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-      "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.3.tgz",
+      "integrity": "sha512-bbtCxCkxcnWhi50I+4Lj6mdz9w3pOXOgEQrID8TCZ/DF51fW7M9GCQW2y45SpBDdHd1Eirm1X/Cf6CkAAe8HPg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
       }
     },
     "node_modules/@types/estree": {
@@ -110,6 +122,15 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/ansi-escape-sequences/node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -120,11 +141,11 @@
       }
     },
     "node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/asn1": {
@@ -139,7 +160,7 @@
     "node_modules/assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
       "engines": {
         "node": ">=0.8"
@@ -148,22 +169,22 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
     },
     "node_modules/balanced-match": {
@@ -175,7 +196,7 @@
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
@@ -211,19 +232,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/cache-point/node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
     "node_modules/catharsis": {
@@ -264,9 +276,9 @@
       }
     },
     "node_modules/command-line-args": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
-      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "dev": true,
       "dependencies": {
         "array-back": "^3.1.0",
@@ -276,6 +288,24 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-args/node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/command-line-args/node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/command-line-tool": {
@@ -309,7 +339,7 @@
     "node_modules/command-line-tool/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/command-line-usage": {
@@ -342,7 +372,7 @@
     "node_modules/command-line-usage/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/common-sequence": {
@@ -357,13 +387,13 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "node_modules/config-master": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
-      "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
+      "integrity": "sha512-n7LBL1zBzYdTpF1mx5DNcZnZn05CWIdsdvtPL4MosvqbBUK3Rq6VWEtGUuF3Y0s9/CIhMejezqlSkP6TnCJ/9g==",
       "dev": true,
       "dependencies": {
         "walk-back": "^2.0.1"
@@ -372,7 +402,7 @@
     "node_modules/config-master/node_modules/walk-back": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-      "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+      "integrity": "sha512-Nb6GvBR8UWX1D+Le+xUq0+Q1kFmRBIWVrfLnQAOmcpEzA9oAxwJ9gIr36t9TWYfzvWRvuMtjHiVsJYEkXWaTAQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -381,7 +411,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true
     },
     "node_modules/coveralls": {
@@ -406,7 +436,7 @@
     "node_modules/dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
@@ -427,16 +457,16 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/dmd": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.1.0.tgz",
-      "integrity": "sha512-0zQIJ873gay1scCTFZvHPWM9mVJBnaylB2NQDI8O9u8O32m00Jb6uxDKexZm8hjTRM7RiWe0FJ32pExHoXdwoQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.2.0.tgz",
+      "integrity": "sha512-uXWxLF1H7TkUAuoHK59/h/ts5cKavm2LnhrIgJWisip4BVzPoXavlwyoprFFn2CzcahKYgvkfaebS6oxzgflkg==",
       "dev": true,
       "dependencies": {
         "array-back": "^6.2.2",
@@ -444,7 +474,7 @@
         "common-sequence": "^2.0.2",
         "file-set": "^4.0.2",
         "handlebars": "^4.7.7",
-        "marked": "^4.0.12",
+        "marked": "^4.2.3",
         "object-get": "^2.1.1",
         "reduce-flatten": "^3.0.1",
         "reduce-unique": "^2.0.1",
@@ -468,7 +498,7 @@
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
       "dependencies": {
         "jsbn": "~0.1.0",
@@ -515,7 +545,7 @@
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -566,10 +596,18 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/find-replace/node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -592,7 +630,7 @@
     "node_modules/fs-then-native": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
+      "integrity": "sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==",
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
@@ -601,28 +639,28 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       },
@@ -632,6 +670,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -657,7 +701,7 @@
     "node_modules/har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -680,7 +724,7 @@
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
       "dependencies": {
         "assert-plus": "^1.0.0",
@@ -695,7 +739,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -711,13 +755,13 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "node_modules/isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
     "node_modules/js-yaml": {
@@ -745,42 +789,42 @@
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
     "node_modules/jsdoc": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
-      "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.0.tgz",
+      "integrity": "sha512-tzTgkklbWKrlaQL2+e3NNgLcZu3NaK2vsHRx7tyHQ+H5jcB9Gx0txSd2eJWlMC/xU1+7LQu4s58Ry0RkuaEQVg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.9.4",
+        "@jsdoc/salty": "^0.2.1",
         "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
-        "klaw": "^4.0.1",
+        "klaw": "^3.0.0",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^8.4.1",
         "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
-        "taffydb": "2.6.2",
         "underscore": "~1.13.2"
       },
       "bin": {
         "jsdoc": "jsdoc.js"
       },
       "engines": {
-        "node": ">=8.15.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsdoc-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-7.1.1.tgz",
-      "integrity": "sha512-0pkuPCzVXiqsDAsVrNFXCkHzlyNepBIDVtwwehry4RJAnZmXtlAz7rh8F9FRz53u3NeynGbex+bpYWwi8lE66A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-8.0.0.tgz",
+      "integrity": "sha512-Rnhor0suB1Ds1abjmFkFfKeD+kSMRN9oHMTMZoJVUrmtCGDwXty+sWMA9sa4xbe4UyxuPjhC7tavZ40mDKK6QQ==",
       "dev": true,
       "dependencies": {
         "array-back": "^6.2.2",
@@ -788,7 +832,7 @@
         "collect-all": "^1.0.4",
         "file-set": "^4.0.2",
         "fs-then-native": "^2.0.0",
-        "jsdoc": "^3.6.10",
+        "jsdoc": "^4.0.0",
         "object-to-spawn-args": "^2.0.1",
         "temp-path": "^1.0.0",
         "walk-back": "^5.1.0"
@@ -807,16 +851,16 @@
       }
     },
     "node_modules/jsdoc-parse": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.1.0.tgz",
-      "integrity": "sha512-n/hDGQJa69IBun1yZAjqzV4gVR41+flZ3bIlm9fKvNe2Xjsd1/+zCo2+R9ls8LxtePgIWbpA1jU7xkB2lRdLLg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.0.tgz",
+      "integrity": "sha512-Afu1fQBEb7QHt6QWX/6eUWvYHJofB90Fjx7FuJYF7mnG9z5BkAIpms1wsnvYLytfmqpEENHs/fax9p8gvMj7dw==",
       "dev": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
         "reduce-extract": "^1.0.0",
-        "sort-array": "^4.1.4",
+        "sort-array": "^4.1.5",
         "test-value": "^3.0.0"
       },
       "engines": {
@@ -833,17 +877,17 @@
       }
     },
     "node_modules/jsdoc-to-markdown": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-7.1.1.tgz",
-      "integrity": "sha512-CI86d63xAVNO+ENumWwmJ034lYe5iGU5GwjtTA11EuphP9tpnoi4hrKgR/J8uME0D+o4KUpVfwX1fjZhc8dEtg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-8.0.0.tgz",
+      "integrity": "sha512-2FQvYkg491+FP6s15eFlgSSWs69CvQrpbABGYBtvAvGWy/lWo8IKKToarT283w59rQFrpcjHl3YdhHCa3l7gXg==",
       "dev": true,
       "dependencies": {
         "array-back": "^6.2.2",
         "command-line-tool": "^0.8.0",
         "config-master": "^3.1.0",
-        "dmd": "^6.1.0",
-        "jsdoc-api": "^7.1.1",
-        "jsdoc-parse": "^6.1.0",
+        "dmd": "^6.2.0",
+        "jsdoc-api": "^8.0.0",
+        "jsdoc-parse": "^6.2.0",
         "walk-back": "^5.1.0"
       },
       "bin": {
@@ -877,7 +921,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "node_modules/jsprim": {
@@ -896,18 +940,18 @@
       }
     },
     "node_modules/klaw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "dev": true,
-      "engines": {
-        "node": ">=14.14.0"
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
       }
     },
     "node_modules/lcov-parse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
       "dev": true,
       "bin": {
         "lcov-parse": "bin/cli.js"
@@ -931,24 +975,24 @@
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
       "dev": true
     },
     "node_modules/lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
       "dev": true
     },
     "node_modules/lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
       "dev": true
     },
     "node_modules/log-driver": {
@@ -977,9 +1021,9 @@
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
-      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.6.tgz",
+      "integrity": "sha512-jRW30YGywD2ESXDc+l17AiritL0uVaSnWsb26f+68qaW9zgbIIr1f4v2Nsvc0+s0Z2N3uX6t/yAw7BwCQ1wMsA==",
       "dev": true,
       "peerDependencies": {
         "@types/markdown-it": "*",
@@ -993,9 +1037,9 @@
       "dev": true
     },
     "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -1007,34 +1051,34 @@
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
     "node_modules/mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "dependencies": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -1044,10 +1088,13 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -1100,7 +1147,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -1109,7 +1156,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1118,19 +1165,19 @@
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "dev": true
     },
     "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -1148,7 +1195,7 @@
     "node_modules/reduce-extract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+      "integrity": "sha512-QF8vjWx3wnRSL5uFMyCjDeDc5EBMiryoT9tz94VvgjKfzecHAVnqmXAwQDcr7X4JmLc2cjkjFGCVzhMqDjgR9g==",
       "dev": true,
       "dependencies": {
         "test-value": "^1.0.1"
@@ -1160,7 +1207,7 @@
     "node_modules/reduce-extract/node_modules/array-back": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
       "dev": true,
       "dependencies": {
         "typical": "^2.6.0"
@@ -1172,7 +1219,7 @@
     "node_modules/reduce-extract/node_modules/test-value": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-      "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+      "integrity": "sha512-wrsbRo7qP+2Je8x8DsK8ovCGyxe3sYfQwOraIY/09A2gFXU9DYKiTF14W4ki/01AEh56kMzAmlj9CaHGDDUBJA==",
       "dev": true,
       "dependencies": {
         "array-back": "^1.0.2",
@@ -1185,7 +1232,7 @@
     "node_modules/reduce-extract/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/reduce-flatten": {
@@ -1209,7 +1256,7 @@
     "node_modules/reduce-without": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
+      "integrity": "sha512-zQv5y/cf85sxvdrKPlfcRzlDn/OqKFThNimYmsS3flmkioKvkUGn2Qg9cJVoQiEvdxFGLE0MQER/9fZ9sUqdxg==",
       "dev": true,
       "dependencies": {
         "test-value": "^2.0.0"
@@ -1221,7 +1268,7 @@
     "node_modules/reduce-without/node_modules/array-back": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
       "dev": true,
       "dependencies": {
         "typical": "^2.6.0"
@@ -1233,7 +1280,7 @@
     "node_modules/reduce-without/node_modules/test-value": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+      "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
       "dev": true,
       "dependencies": {
         "array-back": "^1.0.3",
@@ -1246,7 +1293,7 @@
     "node_modules/reduce-without/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/request": {
@@ -1282,12 +1329,12 @@
       }
     },
     "node_modules/requizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/rollup": {
@@ -1331,9 +1378,9 @@
       "dev": true
     },
     "node_modules/sort-array": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-4.1.4.tgz",
-      "integrity": "sha512-GVFN6Y1sHKrWaSYOJTk9093ZnrBMc9sP3nuhANU44S4xg3rE6W5Z5WyamuT8VpMBbssnetx5faKCua0LEmUnSw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-4.1.5.tgz",
+      "integrity": "sha512-Ya4peoS1fgFN42RN1REk2FgdNOeLIEMKFGJvs7VTP3OklF8+kl2SkpVliZ4tk/PurWsrWRsdNdU+tgyOBkB9sA==",
       "dev": true,
       "dependencies": {
         "array-back": "^5.0.0",
@@ -1373,7 +1420,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/sshpk": {
@@ -1404,7 +1451,7 @@
     "node_modules/stream-connect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+      "integrity": "sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==",
       "dev": true,
       "dependencies": {
         "array-back": "^1.0.2"
@@ -1416,7 +1463,7 @@
     "node_modules/stream-connect/node_modules/array-back": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
       "dev": true,
       "dependencies": {
         "typical": "^2.6.0"
@@ -1428,7 +1475,7 @@
     "node_modules/stream-connect/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/stream-via": {
@@ -1483,19 +1530,13 @@
     "node_modules/table-layout/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
-      "dev": true
-    },
-    "node_modules/taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/temp-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
+      "integrity": "sha512-TvmyH7kC6ZVTYkqCODjJIbgvu0FKiwQpZ4D1aknE7xpcDf/qEOB8KZEK5ef2pfbVoiBhNWs3yx4y+ESMtNYmlg==",
       "dev": true
     },
     "node_modules/test-runner": {
@@ -1543,7 +1584,7 @@
     "node_modules/test-runner/node_modules/file-set/node_modules/array-back": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
       "dev": true,
       "dependencies": {
         "typical": "^2.6.0"
@@ -1555,7 +1596,7 @@
     "node_modules/test-runner/node_modules/reduce-flatten": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+      "integrity": "sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1564,7 +1605,7 @@
     "node_modules/test-runner/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/test-value": {
@@ -1595,7 +1636,7 @@
     "node_modules/test-value/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/tough-cookie": {
@@ -1614,7 +1655,7 @@
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -1626,13 +1667,13 @@
     "node_modules/tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
     "node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "engines": {
         "node": ">=8"
       }
@@ -1644,9 +1685,9 @@
       "dev": true
     },
     "node_modules/uglify-js": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.0.tgz",
-      "integrity": "sha512-x+xdeDWq7FiORDvyIJ0q/waWd4PhjBNOm5dQUOq2AKC0IEjxOS66Ha9tctiVDGcRQuh69K7fgU5oRuTK4cysSg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
       "optional": true,
       "bin": {
@@ -1657,9 +1698,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "node_modules/uri-js": {
@@ -1684,7 +1725,7 @@
     "node_modules/verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
@@ -1707,7 +1748,7 @@
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "node_modules/wordwrapjs": {
@@ -1726,7 +1767,7 @@
     "node_modules/wordwrapjs/node_modules/reduce-flatten": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+      "integrity": "sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1735,13 +1776,13 @@
     "node_modules/wordwrapjs/node_modules/typical": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
       "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/xmlcreate": {
@@ -1753,10 +1794,19 @@
   },
   "dependencies": {
     "@babel/parser": {
-      "version": "7.16.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
-      "integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
       "dev": true
+    },
+    "@jsdoc/salty": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.3.tgz",
+      "integrity": "sha512-bbtCxCkxcnWhi50I+4Lj6mdz9w3pOXOgEQrID8TCZ/DF51fW7M9GCQW2y45SpBDdHd1Eirm1X/Cf6CkAAe8HPg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
+      }
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -1817,6 +1867,14 @@
       "dev": true,
       "requires": {
         "array-back": "^3.0.1"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+          "dev": true
+        }
       }
     },
     "argparse": {
@@ -1829,9 +1887,9 @@
       }
     },
     "array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
+      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg=="
     },
     "asn1": {
       "version": "0.2.6",
@@ -1845,25 +1903,25 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true
     },
     "aws4": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
       "dev": true
     },
     "balanced-match": {
@@ -1875,7 +1933,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
@@ -1906,20 +1964,12 @@
         "array-back": "^4.0.1",
         "fs-then-native": "^2.0.0",
         "mkdirp2": "^1.0.4"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-          "dev": true
-        }
       }
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
     },
     "catharsis": {
@@ -1951,15 +2001,29 @@
       }
     },
     "command-line-args": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.0.tgz",
-      "integrity": "sha512-4zqtU1hYsSJzcJBOcNZIbW5Fbk9BkjCp1pZVhQKoRaWL5J7N4XphDLwo8aWwdQpTugxwu+jf9u2ZhkXiqp5Z6A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "dev": true,
       "requires": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
         "typical": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+          "dev": true
+        },
+        "typical": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+          "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+          "dev": true
+        }
       }
     },
     "command-line-tool": {
@@ -1987,7 +2051,7 @@
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
@@ -2016,7 +2080,7 @@
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
@@ -2030,13 +2094,13 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
     "config-master": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/config-master/-/config-master-3.1.0.tgz",
-      "integrity": "sha1-ZnZjWQUFooO/JqSE1oSJ10xUhdo=",
+      "integrity": "sha512-n7LBL1zBzYdTpF1mx5DNcZnZn05CWIdsdvtPL4MosvqbBUK3Rq6VWEtGUuF3Y0s9/CIhMejezqlSkP6TnCJ/9g==",
       "dev": true,
       "requires": {
         "walk-back": "^2.0.1"
@@ -2045,7 +2109,7 @@
         "walk-back": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-2.0.1.tgz",
-          "integrity": "sha1-VU4qnYdPrEeoywBr9EwvDEmYoKQ=",
+          "integrity": "sha512-Nb6GvBR8UWX1D+Le+xUq0+Q1kFmRBIWVrfLnQAOmcpEzA9oAxwJ9gIr36t9TWYfzvWRvuMtjHiVsJYEkXWaTAQ==",
           "dev": true
         }
       }
@@ -2053,7 +2117,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
       "dev": true
     },
     "coveralls": {
@@ -2072,7 +2136,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
@@ -2087,13 +2151,13 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "dmd": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.1.0.tgz",
-      "integrity": "sha512-0zQIJ873gay1scCTFZvHPWM9mVJBnaylB2NQDI8O9u8O32m00Jb6uxDKexZm8hjTRM7RiWe0FJ32pExHoXdwoQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.2.0.tgz",
+      "integrity": "sha512-uXWxLF1H7TkUAuoHK59/h/ts5cKavm2LnhrIgJWisip4BVzPoXavlwyoprFFn2CzcahKYgvkfaebS6oxzgflkg==",
       "dev": true,
       "requires": {
         "array-back": "^6.2.2",
@@ -2101,7 +2165,7 @@
         "common-sequence": "^2.0.2",
         "file-set": "^4.0.2",
         "handlebars": "^4.7.7",
-        "marked": "^4.0.12",
+        "marked": "^4.2.3",
         "object-get": "^2.1.1",
         "reduce-flatten": "^3.0.1",
         "reduce-unique": "^2.0.1",
@@ -2121,7 +2185,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
@@ -2155,7 +2219,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -2194,12 +2258,19 @@
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "requires": {
         "array-back": "^3.0.1"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+        }
       }
     },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true
     },
     "form-data": {
@@ -2216,37 +2287,43 @@
     "fs-then-native": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-      "integrity": "sha1-GaEk2U2QwiyOBF8ujdbr6jbUjGc=",
+      "integrity": "sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
     "glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
       }
+    },
+    "graceful-fs": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "handlebars": {
       "version": "4.7.7",
@@ -2264,7 +2341,7 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true
     },
     "har-validator": {
@@ -2280,7 +2357,7 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -2291,7 +2368,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -2307,13 +2384,13 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
       "dev": true
     },
     "js-yaml": {
@@ -2338,36 +2415,36 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
     },
     "jsdoc": {
-      "version": "3.6.10",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
-      "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.0.tgz",
+      "integrity": "sha512-tzTgkklbWKrlaQL2+e3NNgLcZu3NaK2vsHRx7tyHQ+H5jcB9Gx0txSd2eJWlMC/xU1+7LQu4s58Ry0RkuaEQVg==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
+        "@jsdoc/salty": "^0.2.1",
         "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
-        "klaw": "^4.0.1",
+        "klaw": "^3.0.0",
         "markdown-it": "^12.3.2",
         "markdown-it-anchor": "^8.4.1",
         "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
-        "taffydb": "2.6.2",
         "underscore": "~1.13.2"
       }
     },
     "jsdoc-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-7.1.1.tgz",
-      "integrity": "sha512-0pkuPCzVXiqsDAsVrNFXCkHzlyNepBIDVtwwehry4RJAnZmXtlAz7rh8F9FRz53u3NeynGbex+bpYWwi8lE66A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-8.0.0.tgz",
+      "integrity": "sha512-Rnhor0suB1Ds1abjmFkFfKeD+kSMRN9oHMTMZoJVUrmtCGDwXty+sWMA9sa4xbe4UyxuPjhC7tavZ40mDKK6QQ==",
       "dev": true,
       "requires": {
         "array-back": "^6.2.2",
@@ -2375,7 +2452,7 @@
         "collect-all": "^1.0.4",
         "file-set": "^4.0.2",
         "fs-then-native": "^2.0.0",
-        "jsdoc": "^3.6.10",
+        "jsdoc": "^4.0.0",
         "object-to-spawn-args": "^2.0.1",
         "temp-path": "^1.0.0",
         "walk-back": "^5.1.0"
@@ -2390,16 +2467,16 @@
       }
     },
     "jsdoc-parse": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.1.0.tgz",
-      "integrity": "sha512-n/hDGQJa69IBun1yZAjqzV4gVR41+flZ3bIlm9fKvNe2Xjsd1/+zCo2+R9ls8LxtePgIWbpA1jU7xkB2lRdLLg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.0.tgz",
+      "integrity": "sha512-Afu1fQBEb7QHt6QWX/6eUWvYHJofB90Fjx7FuJYF7mnG9z5BkAIpms1wsnvYLytfmqpEENHs/fax9p8gvMj7dw==",
       "dev": true,
       "requires": {
         "array-back": "^6.2.2",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
         "reduce-extract": "^1.0.0",
-        "sort-array": "^4.1.4",
+        "sort-array": "^4.1.5",
         "test-value": "^3.0.0"
       },
       "dependencies": {
@@ -2412,17 +2489,17 @@
       }
     },
     "jsdoc-to-markdown": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-7.1.1.tgz",
-      "integrity": "sha512-CI86d63xAVNO+ENumWwmJ034lYe5iGU5GwjtTA11EuphP9tpnoi4hrKgR/J8uME0D+o4KUpVfwX1fjZhc8dEtg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-8.0.0.tgz",
+      "integrity": "sha512-2FQvYkg491+FP6s15eFlgSSWs69CvQrpbABGYBtvAvGWy/lWo8IKKToarT283w59rQFrpcjHl3YdhHCa3l7gXg==",
       "dev": true,
       "requires": {
         "array-back": "^6.2.2",
         "command-line-tool": "^0.8.0",
         "config-master": "^3.1.0",
-        "dmd": "^6.1.0",
-        "jsdoc-api": "^7.1.1",
-        "jsdoc-parse": "^6.1.0",
+        "dmd": "^6.2.0",
+        "jsdoc-api": "^8.0.0",
+        "jsdoc-parse": "^6.2.0",
         "walk-back": "^5.1.0"
       },
       "dependencies": {
@@ -2449,7 +2526,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "jsprim": {
@@ -2465,15 +2542,18 @@
       }
     },
     "klaw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
-      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
     },
     "lcov-parse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
-      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "integrity": "sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==",
       "dev": true
     },
     "linkify-it": {
@@ -2494,24 +2574,24 @@
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA=",
+      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
       "dev": true
     },
     "lodash.padend": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
       "dev": true
     },
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q==",
       "dev": true
     },
     "log-driver": {
@@ -2542,52 +2622,52 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.4.1.tgz",
-      "integrity": "sha512-sLODeRetZ/61KkKLJElaU3NuU2z7MhXf12Ml1WJMSdwpngeofneCRF+JBbat8HiSqhniOMuTemXMrsI7hA6XyA==",
+      "version": "8.6.6",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.6.tgz",
+      "integrity": "sha512-jRW30YGywD2ESXDc+l17AiritL0uVaSnWsb26f+68qaW9zgbIIr1f4v2Nsvc0+s0Z2N3uX6t/yAw7BwCQ1wMsA==",
       "dev": true,
       "requires": {}
     },
     "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "dev": true
     },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
       "dev": true
     },
     "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "requires": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       }
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
       "dev": true
     },
     "mkdirp": {
@@ -2629,7 +2709,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -2638,25 +2718,25 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "dev": true
     },
     "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
     },
     "qs": {
@@ -2668,7 +2748,7 @@
     "reduce-extract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-extract/-/reduce-extract-1.0.0.tgz",
-      "integrity": "sha1-Z/I4W+2mUGG19fQxJmLosIDKFSU=",
+      "integrity": "sha512-QF8vjWx3wnRSL5uFMyCjDeDc5EBMiryoT9tz94VvgjKfzecHAVnqmXAwQDcr7X4JmLc2cjkjFGCVzhMqDjgR9g==",
       "dev": true,
       "requires": {
         "test-value": "^1.0.1"
@@ -2677,7 +2757,7 @@
         "array-back": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
           "dev": true,
           "requires": {
             "typical": "^2.6.0"
@@ -2686,7 +2766,7 @@
         "test-value": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
-          "integrity": "sha1-oJE29y7AQ9J8iTcHwrFZv6196T8=",
+          "integrity": "sha512-wrsbRo7qP+2Je8x8DsK8ovCGyxe3sYfQwOraIY/09A2gFXU9DYKiTF14W4ki/01AEh56kMzAmlj9CaHGDDUBJA==",
           "dev": true,
           "requires": {
             "array-back": "^1.0.2",
@@ -2696,7 +2776,7 @@
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
@@ -2716,7 +2796,7 @@
     "reduce-without": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha1-aK0OrRGFXJo31OglbBW7+Hly/Iw=",
+      "integrity": "sha512-zQv5y/cf85sxvdrKPlfcRzlDn/OqKFThNimYmsS3flmkioKvkUGn2Qg9cJVoQiEvdxFGLE0MQER/9fZ9sUqdxg==",
       "dev": true,
       "requires": {
         "test-value": "^2.0.0"
@@ -2725,7 +2805,7 @@
         "array-back": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
           "dev": true,
           "requires": {
             "typical": "^2.6.0"
@@ -2734,7 +2814,7 @@
         "test-value": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-          "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+          "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
           "dev": true,
           "requires": {
             "array-back": "^1.0.3",
@@ -2744,7 +2824,7 @@
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
@@ -2778,12 +2858,12 @@
       }
     },
     "requizzle": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
-      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.21"
       }
     },
     "rollup": {
@@ -2810,9 +2890,9 @@
       "dev": true
     },
     "sort-array": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-4.1.4.tgz",
-      "integrity": "sha512-GVFN6Y1sHKrWaSYOJTk9093ZnrBMc9sP3nuhANU44S4xg3rE6W5Z5WyamuT8VpMBbssnetx5faKCua0LEmUnSw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-4.1.5.tgz",
+      "integrity": "sha512-Ya4peoS1fgFN42RN1REk2FgdNOeLIEMKFGJvs7VTP3OklF8+kl2SkpVliZ4tk/PurWsrWRsdNdU+tgyOBkB9sA==",
       "dev": true,
       "requires": {
         "array-back": "^5.0.0",
@@ -2842,7 +2922,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "sshpk": {
@@ -2865,7 +2945,7 @@
     "stream-connect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha1-GLyB8u2zW4tdmoAJIAqYUxRCipc=",
+      "integrity": "sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==",
       "dev": true,
       "requires": {
         "array-back": "^1.0.2"
@@ -2874,7 +2954,7 @@
         "array-back": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+          "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
           "dev": true,
           "requires": {
             "typical": "^2.6.0"
@@ -2883,7 +2963,7 @@
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
@@ -2925,21 +3005,15 @@
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
     },
-    "taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
-      "dev": true
-    },
     "temp-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha1-JLFUOXOrRCiW2a02fdnL2/r+kYs=",
+      "integrity": "sha512-TvmyH7kC6ZVTYkqCODjJIbgvu0FKiwQpZ4D1aknE7xpcDf/qEOB8KZEK5ef2pfbVoiBhNWs3yx4y+ESMtNYmlg==",
       "dev": true
     },
     "test-runner": {
@@ -2978,7 +3052,7 @@
             "array-back": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-              "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+              "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
               "dev": true,
               "requires": {
                 "typical": "^2.6.0"
@@ -2989,13 +3063,13 @@
         "reduce-flatten": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-          "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+          "integrity": "sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==",
           "dev": true
         },
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
@@ -3022,7 +3096,7 @@
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
@@ -3040,7 +3114,7 @@
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
@@ -3049,13 +3123,13 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "dev": true
     },
     "typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -3064,16 +3138,16 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.0.tgz",
-      "integrity": "sha512-x+xdeDWq7FiORDvyIJ0q/waWd4PhjBNOm5dQUOq2AKC0IEjxOS66Ha9tctiVDGcRQuh69K7fgU5oRuTK4cysSg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
       "optional": true
     },
     "underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "uri-js": {
@@ -3094,7 +3168,7 @@
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
@@ -3111,7 +3185,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
     },
     "wordwrapjs": {
@@ -3127,13 +3201,13 @@
         "reduce-flatten": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-          "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=",
+          "integrity": "sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==",
           "dev": true
         },
         "typical": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-          "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=",
+          "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
           "dev": true
         }
       }
@@ -3141,7 +3215,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Lloyd Brookes <75pound@gmail.com>",
   "license": "MIT",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">= 8"
   },
   "files": [
     "index.mjs",
@@ -39,15 +39,15 @@
   ],
   "devDependencies": {
     "coveralls": "^3.1.1",
-    "jsdoc-to-markdown": "^7.1.1",
+    "jsdoc-to-markdown": "^8.0.0",
     "rollup": "~1.7.4",
     "test-runner": "^0.5.1"
   },
   "dependencies": {
-    "array-back": "^3.1.0",
+    "array-back": "^4.0.2",
     "find-replace": "^3.0.0",
     "lodash.camelcase": "^4.3.0",
-    "typical": "^4.0.0"
+    "typical": "^5.2.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
I use both `command-line-args` and `command-line-usage` and noticed that the two had differing versions of common dependencies; see: https://npmgraph.js.org/?q=hereby%40v1.7.1

This PR updates everything to the latest versions that still support CJS and Node v8 (and I have another PR for `command-line-usage` that goes with this) and pass the tests. I think that this should still be compatible and not require a major bump.

Feel free to just ignore this PR if it seems undesirable; maybe it'd be better to just major bump and just go all the way up to latest + ESM, but I wanted to try and make things better for the current users.