### PR TITLE
ci(node.js): update workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
 
+    permissions:
+      contents: read
+
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -20,6 +23,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false    
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
This PR:

-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false. They are not used after the initial checkout, and this stops them from accidentally leaking through a script
-   Declares the minimum permissions for the workflow to run at the job level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)