### PR TITLE
chore(package): fix repository url; add homepage and bugs urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
   "name": "command-line-args",
   "version": "6.0.1",
   "description": "A mature, feature-complete library to parse command-line options.",
-  "repository": "https://github.com/75lb/command-line-args",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/75lb/command-line-args.git"
+  },
+  "homepage": "https://github.com/75lb/command-line-args#readme",
+  "bugs": {
+    "url": "https://github.com/75lb/command-line-args/issues"
+  },
   "scripts": {
     "test": "npm run dist && npm run test:ci",
     "test:ci": "test-runner test/*.js test/*.cjs test/internals/*.js",


### PR DESCRIPTION
Sorry, one more minor PR!

The repository URL was fixed by simply running `npm pkg fix`, which is [what `npm publish` does prior to publishing](https://docs.npmjs.com/cli/v10/commands/npm-pkg#description).

The addition of the [`homepage`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#homepage) property allows for the URL to the repo to be correctly displayed when hovered over in VS Code:

![image](https://github.com/user-attachments/assets/de46a716-3bd1-4720-a050-8dbc0a6d5178)

Compared to something like eslint-plugin-regexp, which [does have the homepage set](https://github.com/ota-meshi/eslint-plugin-regexp/blob/2d90a1aca863508647115c76a7b0c23b493eb0e0/package.json#L60):

![image](https://github.com/user-attachments/assets/43f6f798-75dc-4d6d-bc00-df886a08a98d)


The [`bugs`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json?v=true#bugs) property was also added to allow for `npm bugs` to work. 

